### PR TITLE
Use getmypid() which also works on Windows

### DIFF
--- a/src/RedisLock/RedisLock.php
+++ b/src/RedisLock/RedisLock.php
@@ -129,7 +129,7 @@ class RedisLock implements LockInterface {
      * @return string
      */
     protected function createToken() {
-        return posix_getpid() .':'. microtime() .':'. mt_rand(1, 9999);
+        return getmypid() .':'. microtime() .':'. mt_rand(1, 9999);
     }
 
     /**


### PR DESCRIPTION
The previous implementation uses `posix_getpid`, which doesn't work on Windows. Since this package doesn't use any other POSIX features, I'd suggest switching it to a more portable `getmypid` instead 😃

For more information:
* https://secure.php.net/manual/en/function.getmypid.php
* https://secure.php.net/manual/en/function.posix-getpid.php
* https://stackoverflow.com/questions/1176012/difference-between-getmypid-and-posix-getpid